### PR TITLE
Gather all logged runs in a standard date format

### DIFF
--- a/datastores/run_data.ts
+++ b/datastores/run_data.ts
@@ -1,4 +1,7 @@
 import { DefineDatastore, Schema } from "deno-slack-sdk/mod.ts";
+import { SlackAPIClient } from "deno-slack-sdk/types.ts";
+import { DatastoreItem } from "deno-slack-api/types.ts";
+import { DatastoreQueryResponse } from "deno-slack-api/typed-method-types/apps.ts";
 
 export const RUN_DATASTORE = "running_datastore";
 
@@ -20,5 +23,45 @@ const RunningDatastore = DefineDatastore({
     },
   },
 });
+
+/**
+ * Returns the complete collection from the datastore for an expression
+ *
+ * @param client the client to interact with the Slack API
+ * @param expressions optional filters and attributes to refine a query
+ *
+ * @returns ok if the query completed successfully
+ * @returns items a list of responses from the datastore
+ * @returns error the description of any server error
+ */
+export async function queryRunningDatastore(
+  client: SlackAPIClient,
+  expressions?: object,
+): Promise<{
+  ok: boolean;
+  items: DatastoreItem<typeof RunningDatastore.definition>[];
+  error?: string;
+}> {
+  const items: DatastoreItem<typeof RunningDatastore.definition>[] = [];
+  let cursor = undefined;
+
+  do {
+    const runs: DatastoreQueryResponse<typeof RunningDatastore.definition> =
+      await client.apps.datastore.query<typeof RunningDatastore.definition>({
+        datastore: RUN_DATASTORE,
+        cursor,
+        ...expressions,
+      });
+
+    if (!runs.ok) {
+      return { ok: false, items, error: runs.error };
+    }
+
+    cursor = runs.response_metadata?.next_cursor;
+    items.push(...runs.items);
+  } while (cursor);
+
+  return { ok: true, items };
+}
 
 export default RunningDatastore;

--- a/functions/collect_runner_stats_test.ts
+++ b/functions/collect_runner_stats_test.ts
@@ -1,6 +1,6 @@
 import * as mf from "mock-fetch/mod.ts";
 import { SlackFunctionTester } from "deno-slack-sdk/mod.ts";
-import { assertEquals } from "https://deno.land/std@0.153.0/testing/asserts.ts";
+import { assertEquals } from "std/testing/asserts.ts";
 import CollectRunnerStatsFunction from "./collect_runner_stats.ts";
 import { DatastoreItem } from "deno-slack-api/types.ts";
 import RunningDatastore from "../datastores/run_data.ts";

--- a/functions/collect_runner_stats_test.ts
+++ b/functions/collect_runner_stats_test.ts
@@ -6,14 +6,14 @@ import { DatastoreItem } from "deno-slack-api/types.ts";
 import RunningDatastore from "../datastores/run_data.ts";
 
 // Mocked date for stable testing
-Date.now = () => new Date("2023-01-04").getTime();
+Date.now = () => new Date("2023-01-06").getTime();
 
 // Collection of runs stored in the mocked datastore
 const mockRuns: DatastoreItem<typeof RunningDatastore.definition>[] = [
-  { id: "R006", runner: "U0123456", distance: 4, rundate: "2023-01-04" },
-  { id: "R005", runner: "U0123456", distance: 2, rundate: "2023-01-04" },
-  { id: "R004", runner: "U7777777", distance: 2, rundate: "2023-01-02" },
-  { id: "R003", runner: "U0123456", distance: 4, rundate: "2023-01-02" },
+  { id: "R006", runner: "U0123456", distance: 4, rundate: "2023-01-06" },
+  { id: "R005", runner: "U0123456", distance: 2, rundate: "2023-01-06" },
+  { id: "R004", runner: "U7777777", distance: 2, rundate: "2023-01-03" },
+  { id: "R003", runner: "U0123456", distance: 4, rundate: "2022-12-31" },
   { id: "R002", runner: "U7777777", distance: 1, rundate: "2022-12-10" },
   { id: "R001", runner: "U0123456", distance: 2, rundate: "2022-11-11" },
 ];

--- a/functions/collect_runner_stats_test.ts
+++ b/functions/collect_runner_stats_test.ts
@@ -1,0 +1,46 @@
+import * as mf from "mock-fetch/mod.ts";
+import { SlackFunctionTester } from "deno-slack-sdk/mod.ts";
+import { assertEquals } from "https://deno.land/std@0.153.0/testing/asserts.ts";
+import CollectRunnerStatsFunction from "./collect_runner_stats.ts";
+
+// Mocked date for stable testing
+Date.now = () => new Date("2023-01-04").getTime();
+
+// Collection of runs stored in the mocked datastore
+// let mockRuns: DatastoreItem<typeof RunningDatastore.definition>[];
+const mockRuns = [
+  { runner: "U0123456", distance: 4, rundate: "2023-01-04" },
+  { runner: "U0123456", distance: 2, rundate: "2023-01-04" },
+  { runner: "U7777777", distance: 2, rundate: "2023-01-02" },
+  { runner: "U0123456", distance: 4, rundate: "2023-01-02" },
+  { runner: "U7777777", distance: 1, rundate: "2022-12-10" },
+  { runner: "U0123456", distance: 2, rundate: "2022-11-11" },
+];
+
+// Replaces globalThis.fetch with the mocked copy
+mf.install();
+
+mf.mock("POST@/api/apps.datastore.query", () => {
+  return new Response(JSON.stringify({ ok: true, items: mockRuns }));
+});
+
+const { createContext } = SlackFunctionTester("collect_runner_stats");
+
+Deno.test("Collect runner stats", async () => {
+  const { outputs, error } = await CollectRunnerStatsFunction(
+    createContext({ inputs: {} }),
+  );
+
+  const expectedStats = [{
+    runner: "U0123456",
+    weekly_distance: 10,
+    total_distance: 12,
+  }, {
+    runner: "U7777777",
+    weekly_distance: 2,
+    total_distance: 3,
+  }];
+
+  assertEquals(error, undefined);
+  assertEquals(outputs?.runner_stats, expectedStats);
+});

--- a/functions/collect_runner_stats_test.ts
+++ b/functions/collect_runner_stats_test.ts
@@ -2,19 +2,20 @@ import * as mf from "mock-fetch/mod.ts";
 import { SlackFunctionTester } from "deno-slack-sdk/mod.ts";
 import { assertEquals } from "https://deno.land/std@0.153.0/testing/asserts.ts";
 import CollectRunnerStatsFunction from "./collect_runner_stats.ts";
+import { DatastoreItem } from "deno-slack-api/types.ts";
+import RunningDatastore from "../datastores/run_data.ts";
 
 // Mocked date for stable testing
 Date.now = () => new Date("2023-01-04").getTime();
 
 // Collection of runs stored in the mocked datastore
-// let mockRuns: DatastoreItem<typeof RunningDatastore.definition>[];
-const mockRuns = [
-  { runner: "U0123456", distance: 4, rundate: "2023-01-04" },
-  { runner: "U0123456", distance: 2, rundate: "2023-01-04" },
-  { runner: "U7777777", distance: 2, rundate: "2023-01-02" },
-  { runner: "U0123456", distance: 4, rundate: "2023-01-02" },
-  { runner: "U7777777", distance: 1, rundate: "2022-12-10" },
-  { runner: "U0123456", distance: 2, rundate: "2022-11-11" },
+const mockRuns: DatastoreItem<typeof RunningDatastore.definition>[] = [
+  { id: "R006", runner: "U0123456", distance: 4, rundate: "2023-01-04" },
+  { id: "R005", runner: "U0123456", distance: 2, rundate: "2023-01-04" },
+  { id: "R004", runner: "U7777777", distance: 2, rundate: "2023-01-02" },
+  { id: "R003", runner: "U0123456", distance: 4, rundate: "2023-01-02" },
+  { id: "R002", runner: "U7777777", distance: 1, rundate: "2022-12-10" },
+  { id: "R001", runner: "U0123456", distance: 2, rundate: "2022-11-11" },
 ];
 
 // Replaces globalThis.fetch with the mocked copy

--- a/functions/collect_team_stats.ts
+++ b/functions/collect_team_stats.ts
@@ -1,6 +1,6 @@
 import { DefineFunction, Schema, SlackFunction } from "deno-slack-sdk/mod.ts";
 import { SlackAPIClient } from "deno-slack-sdk/types.ts";
-import RunningDatastore, { RUN_DATASTORE } from "../datastores/run_data.ts";
+import { queryRunningDatastore } from "../datastores/run_data.ts";
 
 export const CollectTeamStatsFunction = DefineFunction({
   callback_id: "collect_team_stats",
@@ -15,10 +15,12 @@ export const CollectTeamStatsFunction = DefineFunction({
     properties: {
       weekly_distance: {
         type: Schema.types.number,
+        title: "Weekly distance",
         description: "Total number of miles ran last week",
       },
       percent_change: {
         type: Schema.types.number,
+        title: "Percent change",
         description: "Percent change of miles ran compared to the prior week",
       },
     },
@@ -27,17 +29,21 @@ export const CollectTeamStatsFunction = DefineFunction({
 });
 
 export default SlackFunction(CollectTeamStatsFunction, async ({ client }) => {
-  const today = new Date();
+  const today = new Date(Date.now());
 
   // Collect runs from the past week (days 0-6)
-  const lastWeekStartDate = new Date(new Date().setDate(today.getDate() - 6));
+  const lastWeekStartDate = new Date(
+    new Date(Date.now()).setDate(today.getDate() - 6),
+  );
   const lastWeekDistance = await distanceInWeek(client, lastWeekStartDate);
   if (lastWeekDistance.error) {
     return { error: lastWeekDistance.error };
   }
 
   // Collect runs from the prior week (days 7-13)
-  const priorWeekStartDate = new Date(new Date().setDate(today.getDate() - 13));
+  const priorWeekStartDate = new Date(
+    new Date(Date.now()).setDate(today.getDate() - 13),
+  );
   const priorWeekDistance = await distanceInWeek(client, priorWeekStartDate);
   if (priorWeekDistance.error) {
     return { error: priorWeekDistance.error };
@@ -58,7 +64,15 @@ export default SlackFunction(CollectTeamStatsFunction, async ({ client }) => {
   };
 });
 
-// Sum all logged runs in the seven days following startDate
+/**
+ * Sum all logged runs in the seven days following startDate
+ *
+ * @param client the client to interact with the Slack API
+ * @param startDate the beginning of the week to measure
+ *
+ * @returns total the sum of miles run over the measured week
+ * @returns error the description of any server error
+ */
 async function distanceInWeek(
   client: SlackAPIClient,
   startDate: Date,
@@ -66,18 +80,16 @@ async function distanceInWeek(
   const endDate = new Date(startDate);
   endDate.setDate(endDate.getDate() + 6);
 
-  const runs = await client.apps.datastore.query<
-    typeof RunningDatastore.definition
-  >({
-    datastore: RUN_DATASTORE,
+  const expressions = {
     expression: "#date BETWEEN :start_date AND :end_date",
     expression_attributes: { "#date": "rundate" },
     expression_values: {
-      ":start_date": startDate.toLocaleDateString("en-CA", { timeZone: "UTC" }),
-      ":end_date": endDate.toLocaleDateString("en-CA", { timeZone: "UTC" }),
+      ":start_date": startDate.toISOString().substring(0, 10),
+      ":end_date": endDate.toISOString().substring(0, 10),
     },
-  });
+  };
 
+  const runs = await queryRunningDatastore(client, expressions);
   if (!runs.ok) {
     return { total: 0, error: `Failed to retrieve past runs: ${runs.error}` };
   }

--- a/functions/collect_team_stats_test.ts
+++ b/functions/collect_team_stats_test.ts
@@ -37,12 +37,12 @@ Deno.test("Retrieve the empty set", async () => {
 
 Deno.test("Count only runs from the past week", async () => {
   mockRuns = [
-    { id: "R000", runner: "U0123456", distance: 8, rundate: "2023-01-05" },
-    { id: "R001", runner: "U0123456", distance: 4, rundate: "2023-01-04" },
-    { id: "R002", runner: "U7777777", distance: 2, rundate: "2023-01-02" },
+    { id: "R006", runner: "U0123456", distance: 8, rundate: "2023-01-05" },
+    { id: "R005", runner: "U0123456", distance: 4, rundate: "2023-01-04" },
+    { id: "R004", runner: "U7777777", distance: 2, rundate: "2023-01-02" },
     { id: "R003", runner: "U0123456", distance: 4, rundate: "2022-12-31" },
-    { id: "R004", runner: "U7777777", distance: 6, rundate: "2022-12-29" },
-    { id: "R005", runner: "U8888888", distance: 1, rundate: "2022-12-28" },
+    { id: "R002", runner: "U7777777", distance: 6, rundate: "2022-12-29" },
+    { id: "R001", runner: "U8888888", distance: 1, rundate: "2022-12-28" },
   ];
   const { outputs, error } = await CollectTeamStatsFunction(
     createContext({ inputs: {} }),

--- a/functions/collect_team_stats_test.ts
+++ b/functions/collect_team_stats_test.ts
@@ -6,7 +6,7 @@ import CollectTeamStatsFunction from "./collect_team_stats.ts";
 import RunningDatastore from "../datastores/run_data.ts";
 
 // Mocked date for stable testing
-Date.now = () => new Date("2023-01-04").getTime();
+Date.now = () => new Date("2023-01-06").getTime();
 
 // Collection of runs stored in the mocked datastore
 let mockRuns: DatastoreItem<typeof RunningDatastore.definition>[];
@@ -37,11 +37,11 @@ Deno.test("Retrieve the empty set", async () => {
 
 Deno.test("Count only runs from the past week", async () => {
   mockRuns = [
-    { id: "R006", runner: "U0123456", distance: 8, rundate: "2023-01-05" },
-    { id: "R005", runner: "U0123456", distance: 4, rundate: "2023-01-04" },
+    { id: "R006", runner: "U0123456", distance: 8, rundate: "2023-01-07" },
+    { id: "R005", runner: "U0123456", distance: 4, rundate: "2023-01-06" },
     { id: "R004", runner: "U7777777", distance: 2, rundate: "2023-01-02" },
     { id: "R003", runner: "U0123456", distance: 4, rundate: "2022-12-31" },
-    { id: "R002", runner: "U7777777", distance: 6, rundate: "2022-12-29" },
+    { id: "R002", runner: "U7777777", distance: 6, rundate: "2022-12-31" },
     { id: "R001", runner: "U8888888", distance: 1, rundate: "2022-12-28" },
   ];
   const { outputs, error } = await CollectTeamStatsFunction(
@@ -54,7 +54,7 @@ Deno.test("Count only runs from the past week", async () => {
 
 Deno.test("Handle the infinite change", async () => {
   mockRuns = [
-    { id: "R001", runner: "U0123456", distance: 10, rundate: "2023-01-04" },
+    { id: "R001", runner: "U0123456", distance: 10, rundate: "2023-01-05" },
   ];
   const { outputs, error } = await CollectTeamStatsFunction(
     createContext({ inputs: {} }),

--- a/functions/collect_team_stats_test.ts
+++ b/functions/collect_team_stats_test.ts
@@ -1,0 +1,65 @@
+import * as mf from "mock-fetch/mod.ts";
+import { assertEquals } from "https://deno.land/std@0.153.0/testing/asserts.ts";
+import { SlackFunctionTester } from "deno-slack-sdk/mod.ts";
+import { DatastoreItem } from "deno-slack-api/types.ts";
+import CollectTeamStatsFunction from "./collect_team_stats.ts";
+import RunningDatastore from "../datastores/run_data.ts";
+
+// Mocked date for stable testing
+Date.now = () => new Date("2023-01-04").getTime();
+
+// Collection of runs stored in the mocked datastore
+let mockRuns: DatastoreItem<typeof RunningDatastore.definition>[];
+
+// Replaces globalThis.fetch with the mocked copy
+mf.install();
+
+mf.mock("POST@/api/apps.datastore.query", async (args) => {
+  const body = await args.formData();
+  const dates = JSON.parse(body.get("expression_values") as string);
+  const runs = mockRuns.filter((run) => (
+    run.rundate >= dates[":start_date"] && run.rundate <= dates[":end_date"]
+  ));
+  return new Response(JSON.stringify({ ok: true, items: runs }));
+});
+
+const { createContext } = SlackFunctionTester("collect_team_stats");
+
+Deno.test("Retrieve the empty set", async () => {
+  mockRuns = [];
+  const { outputs, error } = await CollectTeamStatsFunction(
+    createContext({ inputs: {} }),
+  );
+  assertEquals(error, undefined);
+  assertEquals(outputs?.weekly_distance, 0);
+  assertEquals(outputs?.percent_change, 0);
+});
+
+Deno.test("Count only runs from the past week", async () => {
+  mockRuns = [
+    { id: "R000", runner: "U0123456", distance: 8, rundate: "2023-01-05" },
+    { id: "R001", runner: "U0123456", distance: 4, rundate: "2023-01-04" },
+    { id: "R002", runner: "U7777777", distance: 2, rundate: "2023-01-02" },
+    { id: "R003", runner: "U0123456", distance: 4, rundate: "2022-12-31" },
+    { id: "R004", runner: "U7777777", distance: 6, rundate: "2022-12-29" },
+    { id: "R005", runner: "U8888888", distance: 1, rundate: "2022-12-28" },
+  ];
+  const { outputs, error } = await CollectTeamStatsFunction(
+    createContext({ inputs: {} }),
+  );
+  assertEquals(error, undefined);
+  assertEquals(outputs?.weekly_distance, 16);
+  assertEquals(outputs?.percent_change, 1500);
+});
+
+Deno.test("Handle the infinite change", async () => {
+  mockRuns = [
+    { id: "R001", runner: "U0123456", distance: 10, rundate: "2023-01-04" },
+  ];
+  const { outputs, error } = await CollectTeamStatsFunction(
+    createContext({ inputs: {} }),
+  );
+  assertEquals(error, undefined);
+  assertEquals(outputs?.weekly_distance, 10);
+  assertEquals(outputs?.percent_change, 0);
+});

--- a/functions/collect_team_stats_test.ts
+++ b/functions/collect_team_stats_test.ts
@@ -42,7 +42,7 @@ Deno.test("Count only runs from the past week", async () => {
     { id: "R004", runner: "U7777777", distance: 2, rundate: "2023-01-02" },
     { id: "R003", runner: "U0123456", distance: 4, rundate: "2022-12-31" },
     { id: "R002", runner: "U7777777", distance: 6, rundate: "2022-12-31" },
-    { id: "R001", runner: "U8888888", distance: 1, rundate: "2022-12-28" },
+    { id: "R001", runner: "U8888888", distance: 1, rundate: "2022-12-30" },
   ];
   const { outputs, error } = await CollectTeamStatsFunction(
     createContext({ inputs: {} }),

--- a/functions/collect_team_stats_test.ts
+++ b/functions/collect_team_stats_test.ts
@@ -1,5 +1,5 @@
 import * as mf from "mock-fetch/mod.ts";
-import { assertEquals } from "https://deno.land/std@0.153.0/testing/asserts.ts";
+import { assertEquals } from "std/testing/asserts.ts";
 import { SlackFunctionTester } from "deno-slack-sdk/mod.ts";
 import { DatastoreItem } from "deno-slack-api/types.ts";
 import CollectTeamStatsFunction from "./collect_team_stats.ts";

--- a/functions/format_leaderboard.ts
+++ b/functions/format_leaderboard.ts
@@ -10,16 +10,19 @@ export const FormatLeaderboardFunction = DefineFunction({
     properties: {
       team_distance: {
         type: Schema.types.number,
+        title: "Team distance",
         description: "Total number of miles ran last week for the team",
       },
       percent_change: {
         type: Schema.types.number,
+        title: "Percent change",
         description:
           "Percent change of miles ran compared to the prior week for the team",
       },
       runner_stats: {
         type: Schema.types.array,
         items: { type: RunnerStatsType },
+        title: "Runner stats",
         description: "Weekly and all-time total distances for runners",
       },
     },
@@ -29,10 +32,12 @@ export const FormatLeaderboardFunction = DefineFunction({
     properties: {
       teamStatsFormatted: {
         type: Schema.types.string,
+        title: "Formatted team stats",
         description: "A formatted message with team stats",
       },
       runnerStatsFormatted: {
         type: Schema.types.string,
+        title: "Formatted runner stats",
         description: "An ordered leaderboard of runner stats",
       },
     },

--- a/functions/format_leaderboard_test.ts
+++ b/functions/format_leaderboard_test.ts
@@ -1,0 +1,41 @@
+import { SlackFunctionTester } from "deno-slack-sdk/mod.ts";
+import {
+  assertEquals,
+  assertStringIncludes,
+} from "https://deno.land/std@0.153.0/testing/asserts.ts";
+import FormatLeaderboardFunction from "./format_leaderboard.ts";
+
+const { createContext } = SlackFunctionTester("format_leaderboard");
+
+Deno.test("Collect team stats", async () => {
+  const inputs = {
+    team_distance: 11,
+    percent_change: 50,
+    runner_stats: [{
+      runner: "U0123456",
+      weekly_distance: 4,
+      total_distance: 8,
+    }, {
+      runner: "U7777777",
+      weekly_distance: 2,
+      total_distance: 3,
+    }],
+  };
+
+  const { outputs, error } = await FormatLeaderboardFunction(
+    createContext({ inputs }),
+  );
+
+  assertEquals(error, undefined);
+  assertStringIncludes(outputs?.teamStatsFormatted || "", "11 miles");
+  assertStringIncludes(outputs?.teamStatsFormatted || "", "50%");
+
+  assertStringIncludes(
+    outputs?.runnerStatsFormatted || "",
+    "<@U0123456> ran 4 miles last week (8 total)",
+  );
+  assertStringIncludes(
+    outputs?.runnerStatsFormatted || "",
+    "<@U7777777> ran 2 miles last week (3 total)",
+  );
+});

--- a/functions/format_leaderboard_test.ts
+++ b/functions/format_leaderboard_test.ts
@@ -1,8 +1,5 @@
 import { SlackFunctionTester } from "deno-slack-sdk/mod.ts";
-import {
-  assertEquals,
-  assertStringIncludes,
-} from "https://deno.land/std@0.153.0/testing/asserts.ts";
+import { assertEquals, assertStringIncludes } from "std/testing/asserts.ts";
 import FormatLeaderboardFunction from "./format_leaderboard.ts";
 
 const { createContext } = SlackFunctionTester("format_leaderboard");

--- a/functions/log_run_test.ts
+++ b/functions/log_run_test.ts
@@ -1,6 +1,6 @@
 import * as mf from "mock-fetch/mod.ts";
 import { SlackFunctionTester } from "deno-slack-sdk/mod.ts";
-import { assertEquals } from "https://deno.land/std@0.153.0/testing/asserts.ts";
+import { assertEquals } from "std/testing/asserts.ts";
 import LogRunFunction from "./log_run.ts";
 
 // Replaces global fetch with the mocked copy

--- a/functions/log_run_test.ts
+++ b/functions/log_run_test.ts
@@ -16,7 +16,7 @@ Deno.test("Successfully save a run", async () => {
   const inputs = {
     runner: "U0123456",
     distance: 4,
-    rundate: "2022-01-22",
+    rundate: "2023-01-13",
   };
 
   const { error } = await LogRunFunction(createContext({ inputs }));

--- a/import_map.json
+++ b/import_map.json
@@ -2,6 +2,7 @@
   "imports": {
     "deno-slack-sdk/": "https://deno.land/x/deno_slack_sdk@2.2.0/",
     "deno-slack-api/": "https://deno.land/x/deno_slack_api@2.1.1/",
+    "std/": "https://deno.land/std@0.183.0/",
     "mock-fetch/": "https://deno.land/x/mock_fetch@0.3.0/"
   }
 }


### PR DESCRIPTION
### Type of change

- [ ] New sample
- [x] New feature
- [x] Bug fix
- [ ] Documentation

### Summary

This PR paginates over the `running_datastore` datastore to collect all logged runs and stores runs with with the ISO-8601 timestamp. Tests are also returned with a stable date to verify proper month/year wrapping when gathering past weeks.

Closes #7, fixes #22, and resolved #13.

### Requirements

- [x] I’ve checked my submission against the Samples Checklist to ensure it complies with all standards
- [x] I have ensured the changes I am contributing align with existing patterns and have tested and linted my code
- [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct)
