### PR TITLE
Schedule leaderboard posts to a channel defined by environment variables

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,3 @@
+# Rename this file to .env and a channel ID to create the scheduled trigger!
+
+RUNNERS_CHANNEL_ID=

--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 dist
 package
 .DS_Store
+.env
 .slack/apps.dev.json

--- a/README.md
+++ b/README.md
@@ -108,8 +108,8 @@ $ slack trigger create --trigger-def triggers/display_leaderboard_trigger.ts
 The scheduled trigger that displays the leaderboard on a weekly cadence requires
 configurations for which channel to post to. This is done with
 [environment variables](https://api.slack.com/automation/environment-variables#using-trigger-manifest)
-and can be configured by moving `.env.example` to `.env` then adding the
-channel ID of a channel with you and all of your running buddies:
+and can be configured by moving `.env.example` to `.env` then adding the channel
+ID of a channel with you and all of your running buddies:
 
 ```zsh
 $ mv .env.example .env

--- a/README.md
+++ b/README.md
@@ -86,13 +86,34 @@ Interacting with this link will run the associated workflow.
 **Note: triggers won't run the workflow unless the app is either running locally
 or deployed!**
 
+### Scheduled Triggers
+
+A [scheduled trigger](https://api.slack.com/automation/triggers/scheduled) runs
+workflows on a specific cadence and requires no interaction after being created.
+
+Similar to link triggers, these are unique to each version of your app and can
+be created multiple times with various inputs. After being created, and once the
+time is right, these will automatically invoke the workflow.
+
 ### Manual Trigger Creation
 
-To manually create a trigger, use the following command:
+To manually create triggers for logging runs and displaying stats for the whole
+team, use the following commands:
 
 ```zsh
 $ slack trigger create --trigger-def triggers/log_run_trigger.ts
 $ slack trigger create --trigger-def triggers/display_leaderboard_trigger.ts
+```
+
+The scheduled trigger that displays the leaderboard on a weekly cadence requires
+configurations for which channel to post to. This is done with
+[environment variables](https://api.slack.com/automation/environment-variables#using-trigger-manifest)
+and can be configured by moving `.env.example` to `.env` then adding the
+channel ID of a channel with you and all of your running buddies:
+
+```zsh
+$ mv .env.example .env
+$ slack trigger create --trigger-def triggers/display_weekly_stats.ts
 ```
 
 ## Datastores

--- a/triggers/display_leaderboard_trigger.ts
+++ b/triggers/display_leaderboard_trigger.ts
@@ -10,9 +10,6 @@ const DisplayLeaderboardTrigger: Trigger<
   description: "Show stats for the team and individual runners",
   workflow: `#/workflows/${DisplayLeaderboardWorkflow.definition.callback_id}`,
   inputs: {
-    interactivity: {
-      value: TriggerContextData.Shortcut.interactivity,
-    },
     channel: {
       value: TriggerContextData.Shortcut.channel_id,
     },

--- a/triggers/display_weekly_stats.ts
+++ b/triggers/display_weekly_stats.ts
@@ -1,6 +1,7 @@
 import { Trigger } from "deno-slack-sdk/types.ts";
-import { TriggerContextData, TriggerTypes } from "deno-slack-api/mod.ts";
+import { TriggerTypes } from "deno-slack-api/mod.ts";
 import DisplayLeaderboardWorkflow from "../workflows/display_leaderboard_workflow.ts";
+import "std/dotenv/load.ts";
 
 const DisplayWeeklyStats: Trigger<
   typeof DisplayLeaderboardWorkflow.definition
@@ -10,11 +11,8 @@ const DisplayWeeklyStats: Trigger<
   description: "Display weekly running stats on a schedule",
   workflow: `#/workflows/${DisplayLeaderboardWorkflow.definition.callback_id}`,
   inputs: {
-    interactivity: {
-      value: TriggerContextData.Shortcut.interactivity,
-    },
     channel: {
-      value: TriggerContextData.Shortcut.channel_id,
+      value: Deno.env.get("RUNNERS_CHANNEL_ID")!,
     },
   },
   schedule: {

--- a/workflows/display_leaderboard_workflow.ts
+++ b/workflows/display_leaderboard_workflow.ts
@@ -12,9 +12,8 @@ const DisplayLeaderboardWorkflow = DefineWorkflow({
   input_parameters: {
     properties: {
       channel: { type: Schema.slack.types.channel_id },
-      interactivity: { type: Schema.slack.types.interactivity },
     },
-    required: ["channel", "interactivity"],
+    required: ["channel"],
   },
 });
 


### PR DESCRIPTION
### Type of change

- [ ] New sample
- [x] New feature
- [x] Bug fix
- [ ] Documentation

### Summary

This PR uses environment variables to determine which channel the scheduled trigger will post to as a way to fix #14.

### Requirements

- [x] I’ve checked my submission against the Samples Checklist to ensure it complies with all standards
- [x] I have ensured the changes I am contributing align with existing patterns and have tested and linted my code
- [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct)